### PR TITLE
바텀 시트 관련 기능 개선 및 이벤트 처리 추가, 관심 키워드 생성

### DIFF
--- a/frontend/src/components/Chat/ChatMessage.tsx
+++ b/frontend/src/components/Chat/ChatMessage.tsx
@@ -4,8 +4,8 @@ import ChatBrandCard from "./ChatBrandCard";
 import ChatProductItem from "./ChatProductItem";
 import ReactMarkdown from "react-markdown";
 import ChatShareDislikeBox from "./ChatShareDislikeBox";
-import productAndBrandStore from "@/store/productAndBrand.store";
-import { useBottomSheet } from "@/store/bottomSheet.store";
+import productAndBrandStore from "@store/productAndBrand.store";
+import { useBottomSheet } from "@store/bottomSheet.store";
 
 interface ChatMessageProps {
   title: TChatResponse;
@@ -48,9 +48,8 @@ const ChatMessage = (props: ChatMessageProps) => {
                 key={index}
                 className="inline-block"
                 onClick={() => {
-                  console.log("click");
                   setClickedBrand(brand.brand);
-                  open("brandPLP");
+                  open("brandPLP"); // 브랜드 PLP 열기
                 }}
               >
                 <ChatBrandCard

--- a/frontend/src/components/Chat/InterestKeywordsBottomSheet.tsx
+++ b/frontend/src/components/Chat/InterestKeywordsBottomSheet.tsx
@@ -1,0 +1,18 @@
+import BottomSheet from "@common/BottomSheet";
+
+const InterestKeywordsBottomSheet = () => {
+  return (
+    <>
+      <BottomSheet
+        id="interestKeywords"
+        isDragBar={false}
+        isOverlayClose={false}
+      >
+        <BottomSheet.Header isTitleOnly={true}>관심 키워드</BottomSheet.Header>
+        <BottomSheet.Content>ddd</BottomSheet.Content>
+      </BottomSheet>
+    </>
+  );
+};
+
+export default InterestKeywordsBottomSheet;

--- a/frontend/src/components/common/BottomSheet.tsx
+++ b/frontend/src/components/common/BottomSheet.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, useEffect } from "react";
 import { twMerge } from "tailwind-merge";
 import { motion, PanInfo, useDragControls } from "framer-motion";
 import { grabberIcon } from "@assets/assets";
@@ -20,6 +20,14 @@ const BottomSheet = (props: BottomSheetProps) => {
   const isMinimized = sheets[id]?.isMinimized || false;
 
   const dragControls = useDragControls();
+
+  useEffect(() => {
+    if (isMinimized) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "auto";
+    }
+  }, [isMinimized]);
 
   // 스냅 애니메이션 추가
   const handleDragEnd = (

--- a/frontend/src/components/common/BottomSheet.tsx
+++ b/frontend/src/components/common/BottomSheet.tsx
@@ -1,13 +1,13 @@
-import { ReactNode, useEffect } from "react";
+import { ReactNode } from "react";
 import { twMerge } from "tailwind-merge";
 import { motion, PanInfo, useDragControls } from "framer-motion";
 import { grabberIcon } from "@assets/assets";
 import { useBottomSheet } from "@/store/bottomSheet.store";
 
 type BottomSheetProps = {
-  id: string;
-  isDragBar?: boolean;
-  isOverlayClose?: boolean;
+  id: string; // 바텀 시트 ID
+  isDragBar?: boolean; // 드래그 바 여부
+  isOverlayClose?: boolean; // 바텀 시트 밖에 영역 클릭 시 닫힘 여부
   children?: ReactNode;
 };
 

--- a/frontend/src/components/login/LoginBottomSheet.tsx
+++ b/frontend/src/components/login/LoginBottomSheet.tsx
@@ -3,7 +3,6 @@ import Login from "./Login";
 import BottomSheet from "@common/BottomSheet";
 import { useLocation, useNavigate } from "react-router-dom";
 import SignUp from "../signUp/SignUp";
-import { useBottomSheet } from "@/store/bottomSheet.store";
 
 const LoginBottomSheet = () => {
   const location = useLocation();
@@ -11,25 +10,21 @@ const LoginBottomSheet = () => {
 
   const [form, setForm] = useState("");
 
-  const { sheets } = useBottomSheet();
-
   useEffect(() => {
     setForm(location.hash.slice(1));
   }, [location]);
 
   return (
     <>
-      {sheets["login"] && sheets["login"].isOpen && (
-        <BottomSheet id="login" isDragBar={false}>
-          <BottomSheet.Header isTitleOnly={true}>
-            {form === "login" ? "로그인" : "회원가입"}
-          </BottomSheet.Header>
-          <BottomSheet.Content>
-            {form === "login" && <Login />}
-            {form === "signup" && <SignUp />}
-          </BottomSheet.Content>
-        </BottomSheet>
-      )}
+      <BottomSheet id="login" isDragBar={false}>
+        <BottomSheet.Header isTitleOnly={true}>
+          {form === "login" ? "로그인" : "회원가입"}
+        </BottomSheet.Header>
+        <BottomSheet.Content>
+          {form === "login" && <Login />}
+          {form === "signup" && <SignUp />}
+        </BottomSheet.Content>
+      </BottomSheet>
     </>
   );
 };

--- a/frontend/src/components/plp/BrandPLPBottomSheet.tsx
+++ b/frontend/src/components/plp/BrandPLPBottomSheet.tsx
@@ -7,17 +7,17 @@ import BottomSheet from "@common/BottomSheet";
 import PLPHeader from "@components/plp/PLPHeader";
 import PLPControls from "@components/plp/PLPControls";
 import ProductList from "@common/ProductList";
-import FilterPanel from "@components/plp/FilterPanel";
+import FilterPanel from "@/components/plp/FilterBottomSheet";
 import PLPEmptyList from "@components/plp/PLPEmptyList";
 import GenderCategorySelector, {
   GenderCategory,
 } from "@components/plp/GenderCategorySelector";
 
-interface BrandPLPProps {
+interface BrandPLPBottomSheetProps {
   brandName: string;
 }
 
-const BrandPLPPanel = (props: BrandPLPProps) => {
+const BrandPLPBottomSheet = (props: BrandPLPBottomSheetProps) => {
   const { brandName } = props;
 
   const [brandInfo, setBrandInfo] = useState<TBrandPLPResponse | null>(null);
@@ -61,13 +61,13 @@ const BrandPLPPanel = (props: BrandPLPProps) => {
   return (
     <>
       {brandInfo && (
-        <BottomSheet id="BrandPLPPanel" isDragBar={true}>
+        <BottomSheet id="brandPLP" isDragBar={true}>
           {/* 헤더 */}
           <BottomSheet.Header
             isTitleOnly={false}
             className="flex w-full flex-col"
           >
-            <PLPHeader onClick={() => close("BrandPLPPanel")}>
+            <PLPHeader onClick={() => close("brandPLP")}>
               <h2 className="text-body2 font-label">{brandInfo.brand}</h2>
             </PLPHeader>
             <Link to={brandInfo.link}>
@@ -130,4 +130,4 @@ const BrandPLPPanel = (props: BrandPLPProps) => {
     </>
   );
 };
-export default BrandPLPPanel;
+export default BrandPLPBottomSheet;

--- a/frontend/src/components/plp/FilterBottomSheet.tsx
+++ b/frontend/src/components/plp/FilterBottomSheet.tsx
@@ -7,12 +7,12 @@ import GenderCategorySelector, {
   GenderCategory,
 } from "@components/plp/GenderCategorySelector";
 
-interface FilterPanelProps {
+interface FilterBottomSheetProps {
   products: TProduct[];
   applyFilters: (gender: GenderCategory) => void;
 }
 
-const FilterPanel = (props: FilterPanelProps) => {
+const FilterBottomSheet = (props: FilterBottomSheetProps) => {
   const { products, applyFilters } = props;
 
   const [selectedGender, setSelectedGender] = useState<GenderCategory>("ALL");
@@ -53,4 +53,4 @@ const FilterPanel = (props: FilterPanelProps) => {
     </>
   );
 };
-export default FilterPanel;
+export default FilterBottomSheet;

--- a/frontend/src/components/signup/SignUpAdditional.tsx
+++ b/frontend/src/components/signup/SignUpAdditional.tsx
@@ -8,6 +8,7 @@ import userStore from "@store/auth.store";
 import { updateUserData } from "@apis/firebase/auth";
 import { useInput } from "@hooks/useInput";
 import { useNavigate } from "react-router-dom";
+import { useBottomSheet } from "@store/bottomSheet.store";
 
 const SignUpAdditional = () => {
   const navigate = useNavigate();
@@ -20,6 +21,9 @@ const SignUpAdditional = () => {
     sizeType: "",
     sneakerSize: "",
   });
+
+  const { open, close } = useBottomSheet();
+
   const handleSelect = (option: string, key?: string) => {
     setSize((size) => ({ ...size, [key ? key : "sneakerSize"]: option }));
   };
@@ -106,7 +110,14 @@ const SignUpAdditional = () => {
           </div>
         </div>
         <div className="mx-5 mb-[34px] mt-6 h-[114px]">
-          <BottomButton type="submit" title="가입 완료" />
+          <BottomButton
+            type="submit"
+            title="가입 완료"
+            onClick={() => {
+              close("login"); // 회원가입 바텀시트 닫기
+              open("interestKeywords"); // 키워드 바텀 시트 열기
+            }}
+          />
         </div>
       </form>
     </>

--- a/frontend/src/pages/Chat/Chat.tsx
+++ b/frontend/src/pages/Chat/Chat.tsx
@@ -1,18 +1,21 @@
+import { useEffect, useLayoutEffect, useRef } from "react";
 import ChatInput from "@components/Chat/ChatInput";
 import ChatMessage from "@components/Chat/ChatMessage";
 import ChatUserMessage from "@components/Chat/ChatUserMessage";
 import Header from "@common/Header";
-import { useEffect, useLayoutEffect, useRef } from "react";
-import { TChatResponse } from "@/types/chat";
+import { TChatResponse } from "@types/chat";
 import ChatLogin from "@components/Chat/ChatLogin";
-import ChatRecommendedQuestion from "@/components/Chat/ChatRecommendedQuestion";
-import LoginBottomSheet from "@/components/login/LoginBottomSheet";
-import userStore from "@/store/auth.store";
-import useChatStore from "@/store/chat.store";
+import ChatRecommendedQuestion from "@components/Chat/ChatRecommendedQuestion";
+import LoginBottomSheet from "@components/login/LoginBottomSheet";
+import BrandPLPBottomSheet from "@components/plp/BrandPLPBottomSheet";
+import userStore from "@store/auth.store";
+import useChatStore from "@store/chat.store";
+import productAndBrandStore from "@store/productAndBrand.store";
 
 const Chat = () => {
   const { guestMessages, userMessages, loadGuestMessages, loadUserMessages } =
     useChatStore();
+  const { clickedProducts, clickedBrand } = productAndBrandStore();
 
   const { isLoggedIn, user } = userStore();
 
@@ -58,6 +61,8 @@ const Chat = () => {
 
       {/* 로그인 */}
       <LoginBottomSheet />
+      {/* 브랜드 PLP */}
+      {clickedBrand && <BrandPLPBottomSheet brandName={clickedBrand} />}
     </div>
   );
 };

--- a/frontend/src/pages/Chat/Chat.tsx
+++ b/frontend/src/pages/Chat/Chat.tsx
@@ -11,6 +11,8 @@ import BrandPLPBottomSheet from "@components/plp/BrandPLPBottomSheet";
 import userStore from "@store/auth.store";
 import useChatStore from "@store/chat.store";
 import productAndBrandStore from "@store/productAndBrand.store";
+import InterestKeywordsBottomSheet from "@/components/Chat/InterestKeywordsBottomSheet";
+import { useBottomSheet } from "@/store/bottomSheet.store";
 
 const Chat = () => {
   const { guestMessages, userMessages, loadGuestMessages, loadUserMessages } =
@@ -19,7 +21,14 @@ const Chat = () => {
 
   const { isLoggedIn, user } = userStore();
 
+  const { sheets } = useBottomSheet();
+
   const userId = user?.uid!;
+
+  // TODO: 현재 바텀시트 상태 체크용 제거 예정
+  useEffect(() => {
+    console.log("현재 바텀시트 상태:", sheets);
+  }, [sheets]);
 
   useEffect(() => {
     if (isLoggedIn) {
@@ -60,7 +69,11 @@ const Chat = () => {
       <ChatInput />
 
       {/* 로그인 */}
-      <LoginBottomSheet />
+      {sheets["login"] && sheets["login"].isOpen && <LoginBottomSheet />}
+      {/* 관심 키워드 */}
+      {sheets["interestKeywords"] && sheets["interestKeywords"].isOpen && (
+        <InterestKeywordsBottomSheet />
+      )}
       {/* 브랜드 PLP */}
       {clickedBrand && <BrandPLPBottomSheet brandName={clickedBrand} />}
     </div>


### PR DESCRIPTION
## 요약

> 바텀 시트 관련 기능 개선 및 이벤트 처리 추가, 관심 키워드 생성

<br/><br/>

## 변경 내용

- 바텀 시트 props에 주석 추가 및 최소화 사이즈일 때 전체 페이지 스크롤 방지 기능 추가
- 브랜드 PLP 폴더명 변경 및 채팅 브랜드 카드 클릭 시 바텀 시트 열림 이벤트 추가, 필터 바텀 시트 폴더명 변경
- 관심 키워드 바텀 시트 생성 및 회원가입 완료 후 바텀 시트 닫힘 처리 추가, isOpen이 true일 때 Chat 컴포넌트에서 조건부로 바텀 시트가 표시되도록 수정

<br/><br/>

## 이슈 번호 또는 링크
#13 #37 #57

<br/><br/>