### PR TITLE
바텀 시트 기능 개선 및 에러 수정, 로그인 후 동작 추가

### DIFF
--- a/frontend/src/components/common/BottomSheet.tsx
+++ b/frontend/src/components/common/BottomSheet.tsx
@@ -18,6 +18,7 @@ const BottomSheet = (props: BottomSheetProps) => {
 
   const isOpen = sheets[id]?.isOpen || false;
   const isMinimized = sheets[id]?.isMinimized || false;
+  const plp = sheets["brandPLP"].isOpen || false;
 
   const dragControls = useDragControls();
 
@@ -72,7 +73,9 @@ const BottomSheet = (props: BottomSheetProps) => {
           {/* 바텀시트 본체 */}
           <motion.div
             initial={{ y: "100%" }} // 초기값
-            animate={{ y: isMinimized ? "97%" : "0%" }}
+            animate={{
+              y: isMinimized ? (plp ? "83%" : "97%") : "0%",
+            }} // PLP 최소화 임시 처리
             exit={{ y: "100%" }}
             transition={{
               type: "spring",
@@ -86,7 +89,7 @@ const BottomSheet = (props: BottomSheetProps) => {
             dragConstraints={{ top: 0, bottom: 0 }} // 드래그 범위
             dragListener={false}
             onDragEnd={handleDragEnd} // 드래그 끝난 후 스냅 애니메이션 적용
-            className="absolute bottom-0 left-0 z-10 flex max-h-[98vh] w-full flex-col overflow-hidden rounded-t-3xl bg-white shadow-custom"
+            className="absolute bottom-0 left-0 flex max-h-[98vh] w-full flex-col overflow-hidden rounded-t-3xl bg-white shadow-custom"
           >
             {/* 드래그 바 */}
             {isDragBar && (

--- a/frontend/src/components/common/BottomSheet.tsx
+++ b/frontend/src/components/common/BottomSheet.tsx
@@ -18,7 +18,7 @@ const BottomSheet = (props: BottomSheetProps) => {
 
   const isOpen = sheets[id]?.isOpen || false;
   const isMinimized = sheets[id]?.isMinimized || false;
-  const plp = sheets["brandPLP"].isOpen || false;
+  const plp = sheets["brandPLP"]?.isOpen || false;
 
   const dragControls = useDragControls();
 

--- a/frontend/src/components/common/ProductList.tsx
+++ b/frontend/src/components/common/ProductList.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { perfittLogo } from "@/assets/assets";
 
 interface ProductItemProps extends LikeButtonProps {
-  recSize?: string;
+  recSize?: string | null;
   thumb: string;
   brandName: string;
   productName: string;

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -18,7 +18,7 @@ const Layout = () => {
   }, [user?.uid]);
   return (
     <div className="flex h-screen flex-col items-center overflow-hidden">
-      <div className="w-full min-w-80 max-w-5xl">
+      <div className="relative w-full min-w-80 max-w-5xl">
         <Outlet />
       </div>
     </div>

--- a/frontend/src/components/login/Login.tsx
+++ b/frontend/src/components/login/Login.tsx
@@ -5,6 +5,7 @@ import React, { useState } from "react";
 import { signInWithCredential } from "@apis/firebase/auth";
 import userStore from "@store/auth.store";
 import { useNavigate } from "react-router-dom";
+import { useBottomSheet } from "@store/bottomSheet.store";
 
 const Login = () => {
   const navigate = useNavigate();
@@ -18,6 +19,8 @@ const Login = () => {
   });
   const [emailError, setEmailError] = useState("");
   const [passwordError, setPasswordError] = useState("");
+
+  const { close } = useBottomSheet();
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -65,6 +68,7 @@ const Login = () => {
     if (isLoginValid) {
       signInWithCredential(loginData).then(updateUserInfo);
       setIsLoggedIn(true);
+      close("login");
 
       return navigate("/");
     }

--- a/frontend/src/components/login/Login.tsx
+++ b/frontend/src/components/login/Login.tsx
@@ -20,7 +20,7 @@ const Login = () => {
   const [emailError, setEmailError] = useState("");
   const [passwordError, setPasswordError] = useState("");
 
-  const { close } = useBottomSheet();
+  const { closeAll } = useBottomSheet();
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -67,7 +67,7 @@ const Login = () => {
     //값 확인용
     if (isLoginValid) {
       signInWithCredential(loginData).then(updateUserInfo);
-      close("login");
+      closeAll();
 
       return navigate("/");
     }

--- a/frontend/src/components/plp/BrandPLPBottomSheet.tsx
+++ b/frontend/src/components/plp/BrandPLPBottomSheet.tsx
@@ -12,6 +12,7 @@ import PLPEmptyList from "@components/plp/PLPEmptyList";
 import GenderCategorySelector, {
   GenderCategory,
 } from "@components/plp/GenderCategorySelector";
+import userStore from "@store/auth.store";
 
 interface BrandPLPBottomSheetProps {
   brandName: string;
@@ -19,6 +20,9 @@ interface BrandPLPBottomSheetProps {
 
 const BrandPLPBottomSheet = (props: BrandPLPBottomSheetProps) => {
   const { brandName } = props;
+
+  const { user } = userStore();
+  const userFootSize = user?.footInfo || null;
 
   const [brandInfo, setBrandInfo] = useState<TBrandPLPResponse | null>(null);
   const [selectedCategory, setSelectedCategory] =
@@ -106,6 +110,7 @@ const BrandPLPBottomSheet = (props: BrandPLPBottomSheetProps) => {
                   {filteredProducts.map((product, index) => (
                     <ProductList.Item
                       key={`${product.modelNo}-${index}`}
+                      recSize={userFootSize}
                       thumb={product.image}
                       brandName={product.brand}
                       productName={product.modelName}

--- a/frontend/src/components/plp/FilterBottomSheet.tsx
+++ b/frontend/src/components/plp/FilterBottomSheet.tsx
@@ -40,10 +40,13 @@ const FilterBottomSheet = (props: FilterBottomSheetProps) => {
       <BottomSheet id="FilterPanel" isDragBar={false}>
         <BottomSheet.Header isTitleOnly={true}>필터</BottomSheet.Header>
         <BottomSheet.Content className="gap-4">
-          <GenderCategorySelector
-            selectedGender={selectedGender}
-            onClick={(value) => setSelectedGender(value)}
-          />
+          <div className="flex flex-col gap-[0.625rem]">
+            <label className="pb-1 text-[15px] font-label">성별</label>
+            <GenderCategorySelector
+              selectedGender={selectedGender}
+              onClick={(value) => setSelectedGender(value)}
+            />
+          </div>
           <BottomButton
             title={`${filteredCount}개의 상품보기`}
             onClick={handleApplyFilters}

--- a/frontend/src/components/plp/GenderCategorySelector.tsx
+++ b/frontend/src/components/plp/GenderCategorySelector.tsx
@@ -11,20 +11,17 @@ interface GenderCategorySelectorProps {
 const GenderCategorySelector = (props: GenderCategorySelectorProps) => {
   const { selectedGender, onClick } = props;
   return (
-    <div className="flex flex-col gap-[0.625rem]">
-      <label className="pb-1 text-[15px] font-label">성별</label>
-      <CategorySelector>
-        {GENDER_CATEGORIES.map((category) => (
-          <CategorySelector.Item
-            key={category.value}
-            isClicked={category.value === selectedGender}
-            onClick={() => onClick(category.value)}
-          >
-            {category.label}
-          </CategorySelector.Item>
-        ))}
-      </CategorySelector>
-    </div>
+    <CategorySelector>
+      {GENDER_CATEGORIES.map((category) => (
+        <CategorySelector.Item
+          key={category.value}
+          isClicked={category.value === selectedGender}
+          onClick={() => onClick(category.value)}
+        >
+          {category.label}
+        </CategorySelector.Item>
+      ))}
+    </CategorySelector>
   );
 };
 export default GenderCategorySelector;

--- a/frontend/src/components/plp/GenderCategorySelector.tsx
+++ b/frontend/src/components/plp/GenderCategorySelector.tsx
@@ -12,7 +12,7 @@ const GenderCategorySelector = (props: GenderCategorySelectorProps) => {
   const { selectedGender, onClick } = props;
   return (
     <CategorySelector>
-      {GENDER_CATEGORIES.map((category) => (
+      {GENDER_CATEGORIES.map((category: GenderCategory) => (
         <CategorySelector.Item
           key={category.value}
           isClicked={category.value === selectedGender}

--- a/frontend/src/pages/Chat/Chat.tsx
+++ b/frontend/src/pages/Chat/Chat.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useRef } from "react";
+import { motion } from "framer-motion";
 import ChatInput from "@components/Chat/ChatInput";
 import ChatMessage from "@components/Chat/ChatMessage";
 import ChatUserMessage from "@components/Chat/ChatUserMessage";
@@ -11,8 +12,8 @@ import BrandPLPBottomSheet from "@components/plp/BrandPLPBottomSheet";
 import userStore from "@store/auth.store";
 import useChatStore from "@store/chat.store";
 import productAndBrandStore from "@store/productAndBrand.store";
-import InterestKeywordsBottomSheet from "@/components/Chat/InterestKeywordsBottomSheet";
-import { useBottomSheet } from "@/store/bottomSheet.store";
+import InterestKeywordsBottomSheet from "@components/Chat/InterestKeywordsBottomSheet";
+import { useBottomSheet } from "@store/bottomSheet.store";
 
 const Chat = () => {
   const { guestMessages, userMessages, loadGuestMessages, loadUserMessages } =
@@ -22,6 +23,9 @@ const Chat = () => {
   const { isLoggedIn, user } = userStore();
 
   const { sheets } = useBottomSheet();
+  const login = sheets["login"] || {}; // 로그인/회원가입 바텀 상태
+  const interestKeywords = sheets["interestKeywords"] || {}; // 관심 키워드 바텀 상태
+  const brandPLP = sheets["brandPLP"] || {}; // 브랜드 PLP 바텀 상태
 
   const userId = user?.uid!;
 
@@ -66,16 +70,34 @@ const Chat = () => {
       </main>
 
       <ChatRecommendedQuestion />
-      <ChatInput />
+
+      {/* PLP 바텀 최소/최대화일 때 채팅창에 애니메이션 적용 */}
+      <motion.div
+        className="z-[10] w-full"
+        animate={{
+          y: brandPLP.isOpen
+            ? brandPLP.isMinimized
+              ? "0%" // brandPLP가 최소화되었을 때 y축으로 올라옴 (원래 자리)
+              : "100%" // brandPLP 바텀시트가 열렸을 때 y축으로 내려감
+            : "0%", // 기본 상태에서 y축 위치
+        }}
+        initial={false}
+        transition={{ type: "tween", duration: 1 }}
+      >
+        <ChatInput />
+      </motion.div>
 
       {/* 로그인 */}
-      {sheets["login"] && sheets["login"].isOpen && <LoginBottomSheet />}
+      {login.isOpen && <LoginBottomSheet />}
+
       {/* 관심 키워드 */}
-      {sheets["interestKeywords"] && sheets["interestKeywords"].isOpen && (
-        <InterestKeywordsBottomSheet />
-      )}
-      {/* 브랜드 PLP */}
-      {clickedBrand && <BrandPLPBottomSheet brandName={clickedBrand} />}
+      {interestKeywords.isOpen && <InterestKeywordsBottomSheet />}
+
+      {/* PLP */}
+      <div className="z-[8]">
+        {/* 브랜드 PLP */}
+        {clickedBrand && <BrandPLPBottomSheet brandName={clickedBrand} />}
+      </div>
     </div>
   );
 };

--- a/frontend/src/store/bottomSheet.store.ts
+++ b/frontend/src/store/bottomSheet.store.ts
@@ -11,6 +11,7 @@ type BottomSheetState = {
   close: (id: string) => void;
   minimize: (id: string) => void;
   maximize: (id: string) => void;
+  closeAll: () => void;
 };
 
 export const useBottomSheet = create<BottomSheetState>((set) => ({
@@ -51,4 +52,20 @@ export const useBottomSheet = create<BottomSheetState>((set) => ({
         [id]: { ...state.sheets[id], isMinimized: false }, // 최대화 상태로 변경
       },
     })),
+
+  closeAll: () =>
+    set((state) => {
+      const updatedSheets = Object.keys(state.sheets).reduce(
+        (acc, key) => {
+          acc[key] = {
+            ...state.sheets[key],
+            isOpen: false, // 모든 시트의 isOpen을 false로 설정
+          };
+          return acc;
+        },
+        {} as BottomSheetState["sheets"]
+      );
+
+      return { sheets: updatedSheets };
+    }),
 }));


### PR DESCRIPTION
## 요약

> 바텀 시트 기능 개선 및 에러 수정, 로그인 후 동작 추가

<br/><br/>

## 변경 내용

- 필터 바텀에서만 사용하는 label을 GenderCategorySelector에서 분리
- PLP 바텀 열리고 최소화될 때 채팅창 레이아웃 위치 애니메이션 조정
- 성별 카테고리 타입 누락 추가
- 로그인 완료 후 바텀 시트 닫기 기능 추가, 로그인할 경우 모든 바텀 시트 초기화 처리 추가
- sheets["brandPLP"] undefined 에러 해결

<br/><br/>

## 이슈 번호 또는 링크
#35 #37

<br/><br/>