### PR TITLE
회원가입 바텀시트 내 드롭다운 수정, 마이쇼핑 라우터 변경

### DIFF
--- a/frontend/src/components/common/html/DropDown.tsx
+++ b/frontend/src/components/common/html/DropDown.tsx
@@ -13,6 +13,7 @@ type DropDownProps = {
   placeholder: string;
   options: { value: string; label: string }[];
   onChange?: (value: string) => void;
+  menuPlacement? : "top" | "bottom";
 };
 
 export type DropDownRef = {
@@ -20,7 +21,7 @@ export type DropDownRef = {
 };
 
 const DropDown = forwardRef<DropDownRef, DropDownProps>((props, ref) => {
-  const { className, placeholder, options, onChange } = props;
+  const { className, placeholder, options, onChange, menuPlacement = "bottom" } = props;
 
   const [isOpen, setIsOpen] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string>("");
@@ -60,7 +61,7 @@ const DropDown = forwardRef<DropDownRef, DropDownProps>((props, ref) => {
       <div className="relative min-w-0 grow" ref={dropdownRef}>
         <div
           className={twMerge(
-            "flex items-center justify-between border text-body2 font-semibold",
+            "flex items-center justify-between border text-body2",
             className
           )}
           onClick={() => setIsOpen(!isOpen)}
@@ -78,7 +79,7 @@ const DropDown = forwardRef<DropDownRef, DropDownProps>((props, ref) => {
           </div>
         </div>
         {isOpen && (
-          <ul className="absolute top-full z-10 mt-1 max-h-40 w-full cursor-pointer overflow-y-auto rounded-s-md border border-gray-300 bg-white">
+          <ul className={twMerge("absolute z-10 max-h-40 w-full cursor-pointer overflow-y-auto rounded-s-md border border-gray-300 bg-white", menuPlacement === "top" ? "bottom-full mb-1" : "top-full mt-1")}>
             {options.map((option) => (
               <li
                 key={option.value}

--- a/frontend/src/components/signup/SignUpRequired.tsx
+++ b/frontend/src/components/signup/SignUpRequired.tsx
@@ -207,6 +207,7 @@ const SignUpRequired = () => {
               <DropDown
                 ref={dropdownRef}
                 className="h-[45px] gap-2 rounded-[6px] border-[#E4E4E7] px-[10px] py-[14px]"
+                menuPlacement="top"
                 placeholder="년"
                 options={birthYearOptions}
                 onChange={(value) => {
@@ -217,6 +218,7 @@ const SignUpRequired = () => {
               <DropDown
                 ref={dropdownRef}
                 className="h-[45px] gap-2 rounded-[6px] border-[#E4E4E7] px-[10px] py-[14px]"
+                menuPlacement="top"
                 placeholder="월"
                 options={birthMonthOptions}
                 onChange={(value) => {
@@ -227,6 +229,7 @@ const SignUpRequired = () => {
               <DropDown
                 ref={dropdownRef}
                 className="h-[45px] gap-2 rounded-[6px] border-[#E4E4E7] px-[10px] py-[14px]"
+                menuPlacement="top"
                 placeholder="일"
                 options={birthDayOptions}
                 onChange={(value) => {

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -30,10 +30,12 @@ const router = createBrowserRouter(
         {
           path: "/mypage",
           element: <MyPage />,
-        },
-        {
-          path: "/myshopping",
-          element: <MyShopping />,
+          children: [
+            {
+              path: "myshopping",
+              element: <MyShopping />,
+            },
+          ]
         },
         {
           path: "/myfootinfo",


### PR DESCRIPTION
## 요약

> 드롭다운 font weight 다른 것 통일
> 생년월일 드롭다운 메뉴 위쪽으로 열리도록 수정
> 마이쇼핑 라우터 /mypage/myshopping

<br/><br/>

## 변경 내용

> 드롭다운 font weight 인풋과 동일하게 보이도록 수정
> 생년월일 드롭다운 메뉴가 길어져서 바텀시트에 스크롤바가 생기는 현상 발생
>> 생년월일만 위쪽으로 열리도록 수정
> 마이쇼핑 라우터 마이페이지 자식으로 수정

<br/><br/>

## 이슈 번호 또는 링크

#43 #21 #15 

<br/><br/>