### PR TITLE
사파리에서 로그인/회원가입 바텀이 처음 열릴때 최상단 위로 올라갔다가 내려오는 현상 해결 

### DIFF
--- a/frontend/src/hooks/useFocus.ts
+++ b/frontend/src/hooks/useFocus.ts
@@ -16,9 +16,13 @@ const useFocus = <T extends HTMLElement | DropDownRef>(
 
   // 컴포넌트 마운트 시 자동으로 포커스
   useEffect(() => {
-    if (autoFocus) {
-      setFocus();
-    }
+    const focusTimeout = setTimeout(() => {
+      if (autoFocus) {
+        setFocus();
+      }
+    }, 1000);
+
+    return () => clearTimeout(focusTimeout);
   }, [autoFocus, setFocus]);
 
   // Enter 키를 누르면 다음 필드로 포커스 이동

--- a/frontend/src/pages/Chat/Chat.tsx
+++ b/frontend/src/pages/Chat/Chat.tsx
@@ -114,7 +114,7 @@ const Chat = () => {
               : "100%" // brandPLP 바텀시트가 열렸을 때 y축으로 내려감
             : "0%", // 기본 상태에서 y축 위치
         }}
-        initial={false}
+        initial={{ y: "100%" }}
         transition={{ type: "tween", duration: 1 }}
       >
         <ChatInput />


### PR DESCRIPTION
사파리에서 로그인/회원가입 바텀이 처음 열릴때 최상단 위로 올라갔다가 내려오는 현상 발생하였습니다. 확인해보니 바텀이 열리면서 input창에 포커스 되도록 처리되어있어 발생한 것으로 보입니다. input창 포커스에 딜레이를 주어 바텀이 다 올라온 후 포커스 되도록 수정하였습니다.

## 요약

> 사파리에서 로그인/회원가입 바텀이 처음 열릴때 최상단 위로 올라갔다가 내려오는 현상 해결 

<br/><br/>

## 변경 내용

> 사파리에서 로그인/회원가입 바텀이 처음 열릴때 최상단 위로 올라갔다가 내려오는 현상 해결 

<br/><br/>

## 이슈 번호 또는 링크

#112

<br/><br/>