### PR TITLE
상품 리스트 무한스크롤 적용 및 productItem 컴포넌트 분리

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,5 @@
     "prettier@3.3.3": {
       "unplugged": true
     }
-  },
-  "homepage": "https://StepUpper.github.io/stepup_front"
+  }
 }

--- a/frontend/src/components/Chat/ChatSampleQuestions.tsx
+++ b/frontend/src/components/Chat/ChatSampleQuestions.tsx
@@ -11,7 +11,6 @@ interface Question {
 const ChatSampleQuestions = () => {
   const { data } = useAxios<Question[]>(chatApi.getRecommendedQuestion, []);
 
-  const id = useId();
   const [isOpen, setIsOpen] = useState(false);
 
   const handleSampleToggle = () => {
@@ -46,8 +45,8 @@ const ChatSampleQuestions = () => {
 
         <div className="flex flex-col gap-[.875rem]">
           <ul className="flex flex-col gap-1 px-4">
-            {data?.map((q) => (
-              <li key={id} className="list-disc text-body3 text-gray-700">
+            {data?.map((q, index) => (
+              <li key={index} className="list-disc text-body3 text-gray-700">
                 {q.question}
               </li>
             ))}

--- a/frontend/src/components/common/BottomSheet.tsx
+++ b/frontend/src/components/common/BottomSheet.tsx
@@ -81,7 +81,7 @@ const BottomSheet = (props: BottomSheetProps) => {
           <motion.div
             initial={{ y: "100%" }} // 초기값
             animate={{
-              y: isMinimized ? (plp ? "79%" : "97%") : "0%",
+              y: isMinimized ? (plp ? "84%" : "97%") : "0%",
             }} // PLP 최소화 임시 처리
             exit={{ y: "100%" }}
             transition={{

--- a/frontend/src/components/common/ProductItem.tsx
+++ b/frontend/src/components/common/ProductItem.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode, useEffect, useState } from "react";
+import { forwardRef, memo, useCallback, useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import LikeButton, { LikeButtonProps } from "@common/LikeButton";
 import ProductLearnMoreButton from "@common/ProductLearnMoreButton";
@@ -12,15 +12,6 @@ import { TProduct } from "@type/product";
 interface ProductItemProps extends TProduct, LikeButtonProps {
   sneakerSize?: number | null;
 }
-
-const ProductList = ({ children }: { children: ReactNode }) => {
-  return (
-    <ul className="no-scrollbar grid h-[calc(100vh-200px)] w-full grid-cols-2 gap-3 overflow-y-auto md:grid-cols-4">
-      {children}
-    </ul>
-  );
-};
-export default ProductList;
 
 const ProductItem = forwardRef<HTMLLIElement, ProductItemProps>(
   (props, ref) => {
@@ -68,25 +59,28 @@ const ProductItem = forwardRef<HTMLLIElement, ProductItemProps>(
     };
 
     // 좋아요
-    const handleLikeClick = async (e: React.MouseEvent) => {
-      e.stopPropagation();
+    const handleLikeClick = useCallback(
+      async (e: React.MouseEvent) => {
+        e.stopPropagation();
 
-      if (isLoggedIn) {
-        await addOrRemoveShoeFromLikes(user?.uid!, {
-          brand,
-          productName,
-          imgUrl,
-          modelNo,
-          customerImg,
-          customerLink,
-          price,
-        });
-        updateUserInfo();
-      } else {
-        console.log("로그인이 필요합니다.");
-        // 여기서 로그인하라는 채팅을 띄워주면 좋을 듯 하다. 일단 나중에 ..
-      }
-    };
+        if (isLoggedIn) {
+          await addOrRemoveShoeFromLikes(user?.uid!, {
+            brand,
+            productName,
+            imgUrl,
+            modelNo,
+            customerImg,
+            customerLink,
+            price,
+          });
+          updateUserInfo();
+        } else {
+          console.log("로그인이 필요합니다.");
+          // 여기서 로그인하라는 채팅을 띄워주면 좋을 듯 하다. 일단 나중에 ..
+        }
+      },
+      [isLiked, user?.uid]
+    );
 
     return (
       <li
@@ -145,4 +139,4 @@ const ProductItem = forwardRef<HTMLLIElement, ProductItemProps>(
 );
 
 ProductItem.displayName = "ProductItem";
-ProductList.Item = ProductItem;
+export default memo(ProductItem);

--- a/frontend/src/components/common/ProductList.tsx
+++ b/frontend/src/components/common/ProductList.tsx
@@ -6,11 +6,12 @@ import Img from "@common/html/Img";
 import { shoeImg } from "@assets/assets";
 import userStore from "@store/auth.store";
 import { addOrRemoveShoeFromLikes } from "@apis/firebase/likeFirestore";
-import { useSizeConversion } from "@hooks/useSizeConversion";
 import { addRecentProduct } from "@utils/storeRecentProducts";
 import { TProduct } from "@type/product";
 
-interface ProductItemProps extends TProduct, LikeButtonProps {}
+interface ProductItemProps extends TProduct, LikeButtonProps {
+  sneakerSize?: number | null;
+}
 
 const ProductList = ({ children }: { children: ReactNode }) => {
   return (
@@ -33,6 +34,7 @@ const ProductItem = forwardRef<HTMLLIElement, ProductItemProps>(
       customerImg,
       price,
       isLiked,
+      sneakerSize,
     } = props;
 
     const location = useLocation();
@@ -41,11 +43,6 @@ const ProductItem = forwardRef<HTMLLIElement, ProductItemProps>(
     const [type, setType] = useState("");
 
     const { isLoggedIn, user, updateUserInfo } = userStore();
-    const sizeType = user?.sizeType ?? "mm";
-    const sneakerSize = user?.sneakerSize ?? null;
-
-    // 신발 사이즈 변환
-    const convertedSneakerSize = useSizeConversion(sizeType, sneakerSize);
 
     useEffect(() => {
       setType(location.hash.slice(1));
@@ -115,10 +112,10 @@ const ProductItem = forwardRef<HTMLLIElement, ProductItemProps>(
             </div>
           </div>
           {/* 사이즈 추천 */}
-          {convertedSneakerSize && (
+          {sneakerSize && (
             <span className="absolute left-2.5 top-2 flex rounded bg-gradient-to-r from-[#e8f4fe] to-[#ffecfe] p-[0.31rem]">
               <strong className="bg-gradient-to-r from-[#12C2E9] via-[#C471ED] to-[#F64F59] bg-clip-text text-caption1 font-label leading-4 text-transparent">
-                {convertedSneakerSize}mm 추천
+                {sneakerSize}mm 추천
               </strong>
             </span>
           )}

--- a/frontend/src/components/common/ProductList.tsx
+++ b/frontend/src/components/common/ProductList.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from "react";
+import { forwardRef, ReactNode, useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import LikeButton, { LikeButtonProps } from "@common/LikeButton";
 import ProductLearnMoreButton from "@common/ProductLearnMoreButton";
@@ -21,38 +21,9 @@ const ProductList = ({ children }: { children: ReactNode }) => {
 };
 export default ProductList;
 
-const ProductItem = (props: ProductItemProps) => {
-  const {
-    shoeId,
-    productName,
-    imgUrl,
-    modelNo,
-    brand,
-    customerLink,
-    customerImg,
-    price,
-    isLiked,
-  } = props;
-
-  const location = useLocation();
-  const navigate = useNavigate();
-
-  const [type, setType] = useState("");
-
-  const { isLoggedIn, user, updateUserInfo } = userStore();
-  const sizeType = user?.sizeType ?? "mm";
-  const sneakerSize = user?.sneakerSize ?? null;
-
-  // 신발 사이즈 변환
-  const convertedSneakerSize = useSizeConversion(sizeType, sneakerSize);
-
-  useEffect(() => {
-    setType(location.hash.slice(1));
-  }, [location]);
-
-  // 브릿지
-  const handleBridgeNavigation = () => {
-    const recentProducts = {
+const ProductItem = forwardRef<HTMLLIElement, ProductItemProps>(
+  (props, ref) => {
+    const {
       shoeId,
       productName,
       imgUrl,
@@ -61,86 +32,118 @@ const ProductItem = (props: ProductItemProps) => {
       customerLink,
       customerImg,
       price,
-    };
-    addRecentProduct(recentProducts);
+      isLiked,
+    } = props;
 
-    navigate(
-      `/bridge?type=${type}&brandName=${brand}&productName=${productName}&customerImg=${customerImg}&customerLink=${customerLink}`
-    );
-  };
+    const location = useLocation();
+    const navigate = useNavigate();
 
-  // 좋아요
-  const handleLikeClick = async (e: React.MouseEvent) => {
-    e.stopPropagation();
+    const [type, setType] = useState("");
 
-    if (isLoggedIn) {
-      await addOrRemoveShoeFromLikes(user?.uid!, {
-        brand,
+    const { isLoggedIn, user, updateUserInfo } = userStore();
+    const sizeType = user?.sizeType ?? "mm";
+    const sneakerSize = user?.sneakerSize ?? null;
+
+    // 신발 사이즈 변환
+    const convertedSneakerSize = useSizeConversion(sizeType, sneakerSize);
+
+    useEffect(() => {
+      setType(location.hash.slice(1));
+    }, [location]);
+
+    // 브릿지
+    const handleBridgeNavigation = () => {
+      const recentProducts = {
+        shoeId,
         productName,
         imgUrl,
         modelNo,
-        customerImg,
+        brand,
         customerLink,
+        customerImg,
         price,
-      });
-      updateUserInfo();
-    } else {
-      console.log("로그인이 필요합니다.");
-      // 여기서 로그인하라는 채팅을 띄워주면 좋을 듯 하다. 일단 나중에 ..
-    }
-  };
+      };
+      addRecentProduct(recentProducts);
 
-  return (
-    <li
-      className="w-full min-w-[136px] cursor-pointer list-none"
-      onClick={handleBridgeNavigation}
-    >
-      {/* 상단 이미지 영역 */}
-      <div className="relative">
-        <div className="w-full overflow-hidden rounded-[0.39rem] bg-grey-50">
-          {/* 신발 이미지 */}
-          <div
-            className="item-center mt-[-10px] size-full min-h-[136px]"
-            style={{ aspectRatio: "1/1" }}
-          >
-            <Img
-              src={imgUrl}
-              alt={productName}
-              fallbackSrc={shoeImg}
-              className="mt-[20px]"
-              errorStyle="w-[60%] mt-[10px] opacity-100"
-            />
+      navigate(
+        `/bridge?type=${type}&brandName=${brand}&productName=${productName}&customerImg=${customerImg}&customerLink=${customerLink}`
+      );
+    };
+
+    // 좋아요
+    const handleLikeClick = async (e: React.MouseEvent) => {
+      e.stopPropagation();
+
+      if (isLoggedIn) {
+        await addOrRemoveShoeFromLikes(user?.uid!, {
+          brand,
+          productName,
+          imgUrl,
+          modelNo,
+          customerImg,
+          customerLink,
+          price,
+        });
+        updateUserInfo();
+      } else {
+        console.log("로그인이 필요합니다.");
+        // 여기서 로그인하라는 채팅을 띄워주면 좋을 듯 하다. 일단 나중에 ..
+      }
+    };
+
+    return (
+      <li
+        ref={ref}
+        className="w-full min-w-[136px] cursor-pointer list-none"
+        onClick={handleBridgeNavigation}
+      >
+        {/* 상단 이미지 영역 */}
+        <div className="relative">
+          <div className="w-full overflow-hidden rounded-[0.39rem] bg-grey-50">
+            {/* 신발 이미지 */}
+            <div
+              className="item-center mt-[-10px] size-full min-h-[136px]"
+              style={{ aspectRatio: "1/1" }}
+            >
+              <Img
+                src={imgUrl}
+                alt={productName}
+                fallbackSrc={shoeImg}
+                className="mt-[20px]"
+                errorStyle="w-[60%] mt-[10px] opacity-100"
+              />
+            </div>
+          </div>
+          {/* 사이즈 추천 */}
+          {convertedSneakerSize && (
+            <span className="absolute left-2.5 top-2 flex rounded bg-gradient-to-r from-[#e8f4fe] to-[#ffecfe] p-[0.31rem]">
+              <strong className="bg-gradient-to-r from-[#12C2E9] via-[#C471ED] to-[#F64F59] bg-clip-text text-caption1 font-label leading-4 text-transparent">
+                {convertedSneakerSize}mm 추천
+              </strong>
+            </span>
+          )}
+          {/* 좋아요 버튼 */}
+          <LikeButton
+            className="absolute right-[0.69rem] top-2"
+            isLiked={isLiked}
+            onClick={handleLikeClick}
+          />
+          {/* 판매처 이미지 */}
+          <div className="bg-grey-300 absolute -bottom-3 right-1.5 size-6 rounded-full">
+            <Img src={customerImg} alt={brand} errorStyle="w-full opacity-40" />
           </div>
         </div>
-        {/* 사이즈 추천 */}
-        {convertedSneakerSize && (
-          <span className="absolute left-2.5 top-2 flex rounded bg-gradient-to-r from-[#e8f4fe] to-[#ffecfe] p-[0.31rem]">
-            <strong className="bg-gradient-to-r from-[#12C2E9] via-[#C471ED] to-[#F64F59] bg-clip-text text-caption1 font-label leading-4 text-transparent">
-              {convertedSneakerSize}mm 추천
-            </strong>
-          </span>
-        )}
-        {/* 좋아요 버튼 */}
-        <LikeButton
-          className="absolute right-[0.69rem] top-2"
-          isLiked={isLiked}
-          onClick={handleLikeClick}
-        />
-        {/* 판매처 이미지 */}
-        <div className="bg-grey-300 absolute -bottom-3 right-1.5 size-6 rounded-full">
-          <Img src={customerImg} alt={brand} errorStyle="w-full opacity-40" />
+        {/* 하단 신발 정보 */}
+        <div className="flex flex-col gap-2.5 px-0 py-2.5 text-body3 sm:px-1.5">
+          <div className="flex flex-col gap-[3px]">
+            <strong className="font-paragraph">{brand}</strong>
+            <h3 className="truncate font-label">{productName}</h3>
+          </div>
+          {price && <p className="font-label">{price}</p>}
+          <ProductLearnMoreButton />
         </div>
-      </div>
-      {/* 하단 신발 정보 */}
-      <div className="flex flex-col gap-2.5 px-0 py-2.5 text-body3 sm:px-1.5">
-        <div className="flex flex-col gap-[3px]">
-          <strong className="font-paragraph">{brand}</strong>
-          <h3 className="truncate font-label">{productName}</h3>
-        </div>
-        {price && <p className="font-label">{price}</p>}
-        <ProductLearnMoreButton />
-      </div>
-    </li>
-  );
-};
+      </li>
+    );
+  }
+);
 ProductList.Item = ProductItem;

--- a/frontend/src/components/common/ProductList.tsx
+++ b/frontend/src/components/common/ProductList.tsx
@@ -146,4 +146,6 @@ const ProductItem = forwardRef<HTMLLIElement, ProductItemProps>(
     );
   }
 );
+
+ProductItem.displayName = "ProductItem";
 ProductList.Item = ProductItem;

--- a/frontend/src/components/myshopping/LikedProducts.tsx
+++ b/frontend/src/components/myshopping/LikedProducts.tsx
@@ -1,9 +1,16 @@
 import userStore from "@store/auth.store";
-import ProductList from "@common/ProductList";
+import ProductItem from "@components/common/ProductItem";
 import { shoeHeart } from "@assets/assets";
+import { useSizeConversion } from "@/hooks/useSizeConversion";
 
 const LikedProducts = () => {
-  const { likeShoes } = userStore();
+  const { user, likeShoes } = userStore();
+
+  const sizeType = user?.sizeType ?? "mm";
+  const sneakerSize = user?.sneakerSize ?? null;
+
+  // 신발 사이즈 변환
+  const convertedSneakerSize = useSizeConversion(sizeType, sneakerSize);
 
   return (
     <>
@@ -13,14 +20,14 @@ const LikedProducts = () => {
         </p>
         {likeShoes && likeShoes.length > 0 ? (
           <>
-            <ProductList>
+            <ul className="no-scrollbar grid h-[calc(100vh-200px)] w-full grid-cols-2 gap-3 overflow-y-auto md:grid-cols-4">
               {likeShoes &&
                 likeShoes.map((product, index) => {
                   const isLiked = likeShoes?.some(
                     (shoe) => shoe.shoeId === product.brand + product.modelNo
                   );
                   return (
-                    <ProductList.Item
+                    <ProductItem
                       key={index}
                       shoeId={product.shoeId}
                       modelNo={product.modelNo}
@@ -31,10 +38,11 @@ const LikedProducts = () => {
                       customerLink={product.customerLink}
                       customerImg={product.customerImg || undefined}
                       isLiked={isLiked}
+                      sneakerSize={convertedSneakerSize}
                     />
                   );
                 })}
-            </ProductList>
+            </ul>
             <div className="mx-auto grid grid-cols-2 justify-items-center gap-[11px] py-[16px]"></div>
           </>
         ) : (

--- a/frontend/src/components/myshopping/RecentProducts.tsx
+++ b/frontend/src/components/myshopping/RecentProducts.tsx
@@ -1,17 +1,24 @@
-import ProductList from "@common/ProductList";
 import { useState, useEffect } from "react";
+import ProductItem from "@common/ProductItem";
 import {
   TRecentProductItem,
   getRecentProducts,
 } from "@utils/storeRecentProducts";
 import { shoeEye } from "@assets/assets";
 import userStore from "@store/auth.store";
+import { useSizeConversion } from "@hooks/useSizeConversion";
 
 const RecentProducts = () => {
-  const { likeShoes } = userStore();
+  const { user, likeShoes } = userStore();
   const [recentProducts, setRecentProducts] = useState<TRecentProductItem[]>(
     []
   );
+
+  const sizeType = user?.sizeType ?? "mm";
+  const sneakerSize = user?.sneakerSize ?? null;
+
+  // 신발 사이즈 변환
+  const convertedSneakerSize = useSizeConversion(sizeType, sneakerSize);
 
   useEffect(() => {
     const products = getRecentProducts();
@@ -27,7 +34,7 @@ const RecentProducts = () => {
         </p>
         {recentProducts && recentProducts.length > 0 ? (
           <>
-            <ProductList>
+            <ul className="no-scrollbar grid h-[calc(100vh-200px)] w-full grid-cols-2 gap-3 overflow-y-auto md:grid-cols-4">
               {recentProducts &&
                 recentProducts.map((product, index) => {
                   const isLiked = likeShoes?.some(
@@ -35,7 +42,7 @@ const RecentProducts = () => {
                   );
 
                   return (
-                    <ProductList.Item
+                    <ProductItem
                       key={index}
                       shoeId={product.shoeId}
                       modelNo={product.modelNo}
@@ -46,10 +53,11 @@ const RecentProducts = () => {
                       customerLink={product.customerLink}
                       customerImg={product.customerImg || undefined}
                       isLiked={isLiked}
+                      sneakerSize={convertedSneakerSize}
                     />
                   );
                 })}
-            </ProductList>
+            </ul>
             <div className="mx-auto grid grid-cols-2 justify-items-center gap-[11px] py-[16px]"></div>
           </>
         ) : (

--- a/frontend/src/components/plp/BrandPLP.tsx
+++ b/frontend/src/components/plp/BrandPLP.tsx
@@ -7,7 +7,7 @@ import PLPHeader from "@components/plp/PLPHeader";
 import GenderCategorySelector, {
   GenderCategory,
 } from "@components/plp/GenderCategorySelector";
-import PLPProductDisplay from "@components/plp/PLPProductDisplay";
+import PLPProductList from "@components/plp/PLPProductList";
 import FilterBottomSheet from "@components/plp/FilterBottomSheet";
 import Error from "@common/Error";
 import PLPLoading from "@components/plp/PLPLoading";
@@ -75,7 +75,7 @@ const BrandPLP = (props: BrandPLPProps) => {
           />
 
           {/* 상품 영역 */}
-          <PLPProductDisplay products={filteredProducts} />
+          <PLPProductList products={filteredProducts} />
 
           {/* 필터 바텀 */}
           <FilterBottomSheet

--- a/frontend/src/components/plp/BrandPLP.tsx
+++ b/frontend/src/components/plp/BrandPLP.tsx
@@ -38,8 +38,6 @@ const BrandPLP = (props: BrandPLPProps) => {
         return product.gender === selectedCategory;
       }) || [];
     setFilteredProducts(newFilteredProducts);
-
-    console.log(filteredProducts);
   }, [data, selectedCategory]);
 
   // 필터 적용

--- a/frontend/src/components/plp/PLPProductDisplay.tsx
+++ b/frontend/src/components/plp/PLPProductDisplay.tsx
@@ -32,7 +32,6 @@ const PLPProductDisplay = (props: PLPProductDisplayProps) => {
   // 데이터가 변경되면 현재 limit만큼의 데이터를 displayData에 설정
   useEffect(() => {
     setDisplayData(products.slice(0, itemsSize));
-    console.log(displayData);
   }, [products, itemsSize]);
 
   // 2. 스크롤 감지해서 추가 데이터 로딩
@@ -51,7 +50,7 @@ const PLPProductDisplay = (props: PLPProductDisplayProps) => {
 
       if (node) observer.current.observe(node); // 새로운 엘리먼트 감시
     },
-    [itemsSize]
+    [itemsSize, products.length]
   );
 
   return (

--- a/frontend/src/components/plp/PLPProductDisplay.tsx
+++ b/frontend/src/components/plp/PLPProductDisplay.tsx
@@ -1,9 +1,10 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import PLPControls from "@components/plp/PLPControls";
 import ProductList from "@common/ProductList";
 import PLPEmptyList from "@components/plp/PLPEmptyList";
 import userStore from "@store/auth.store";
-import { TProductResponse } from "@/types/product";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { TProductResponse } from "@type/product";
+import { useSizeConversion } from "@hooks/useSizeConversion";
 
 interface PLPProductDisplayProps {
   products: TProductResponse[];
@@ -12,7 +13,13 @@ interface PLPProductDisplayProps {
 const PLPProductDisplay = (props: PLPProductDisplayProps) => {
   const { products } = props;
 
-  const { likeShoes } = userStore();
+  const { user, likeShoes } = userStore();
+
+  const sizeType = user?.sizeType ?? "mm";
+  const sneakerSize = user?.sneakerSize ?? null;
+
+  // 신발 사이즈 변환
+  const convertedSneakerSize = useSizeConversion(sizeType, sneakerSize);
 
   const limit = 20;
   const [itemsSize, setItemsSize] = useState(limit);
@@ -71,6 +78,7 @@ const PLPProductDisplay = (props: PLPProductDisplayProps) => {
                     brand={product.brand}
                     customerLink={product.link}
                     isLiked={isLiked}
+                    sneakerSize={convertedSneakerSize}
                   />
                 );
               }

--- a/frontend/src/components/plp/PLPProductList.tsx
+++ b/frontend/src/components/plp/PLPProductList.tsx
@@ -1,16 +1,16 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import PLPControls from "@components/plp/PLPControls";
-import ProductList from "@common/ProductList";
+import ProductItem from "@components/common/ProductItem";
 import PLPEmptyList from "@components/plp/PLPEmptyList";
 import userStore from "@store/auth.store";
 import { TProductResponse } from "@type/product";
 import { useSizeConversion } from "@hooks/useSizeConversion";
 
-interface PLPProductDisplayProps {
+interface PLPProductListProps {
   products: TProductResponse[];
 }
 
-const PLPProductDisplay = (props: PLPProductDisplayProps) => {
+const PLPProductList = (props: PLPProductListProps) => {
   const { products } = props;
 
   const { user, likeShoes } = userStore();
@@ -32,6 +32,7 @@ const PLPProductDisplay = (props: PLPProductDisplayProps) => {
   // 데이터가 변경되면 현재 limit만큼의 데이터를 displayData에 설정
   useEffect(() => {
     setDisplayData(products.slice(0, itemsSize));
+    console.log(displayData)
   }, [products, itemsSize]);
 
   // 2. 스크롤 감지해서 추가 데이터 로딩
@@ -58,31 +59,14 @@ const PLPProductDisplay = (props: PLPProductDisplayProps) => {
       <PLPControls totalItems={products.length} />
       <div className="px-4 pb-6">
         {displayData.length > 0 ? (
-          <ProductList>
+          <ul className="no-scrollbar grid h-[calc(100vh-200px)] w-full grid-cols-2 gap-3 overflow-y-auto md:grid-cols-4">
             {displayData.map((product, index) => {
-              const isLiked = likeShoes?.some(
-                (shoe) => shoe.shoeId === product.brand + product.modelNo
-              );
               const shoeId = product.brand + product.modelNo;
+              const isLiked =likeShoes?.some((shoe) => shoe.shoeId === shoeId);
 
-              if (index === displayData.length - 1) {
-                return (
-                  <ProductList.Item
-                    ref={lastElementRef}
-                    key={`${shoeId}_${index}`}
-                    shoeId={shoeId}
-                    productName={product.modelName}
-                    imgUrl={product.image}
-                    modelNo={product.modelNo}
-                    brand={product.brand}
-                    customerLink={product.link}
-                    isLiked={isLiked}
-                    sneakerSize={convertedSneakerSize}
-                  />
-                );
-              }
               return (
-                <ProductList.Item
+                <ProductItem
+                  ref={index === displayData.length - 1 ? lastElementRef : null}
                   key={shoeId + index}
                   shoeId={shoeId}
                   productName={product.modelName}
@@ -91,10 +75,11 @@ const PLPProductDisplay = (props: PLPProductDisplayProps) => {
                   brand={product.brand}
                   customerLink={product.link}
                   isLiked={isLiked}
+                  sneakerSize={convertedSneakerSize}
                 />
               );
             })}
-          </ProductList>
+          </ul>
         ) : (
           <PLPEmptyList />
         )}
@@ -102,4 +87,4 @@ const PLPProductDisplay = (props: PLPProductDisplayProps) => {
     </>
   );
 };
-export default PLPProductDisplay;
+export default memo(PLPProductList);

--- a/frontend/src/components/plp/ProductsPLP.tsx
+++ b/frontend/src/components/plp/ProductsPLP.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 // import { chatApi } from "@apis/services/chat";
 import PLPHeader from "@components/plp/PLPHeader";
 import { GenderCategory } from "@components/plp/GenderCategorySelector";
-import PLPProductDisplay from "@components/plp/PLPProductDisplay";
+import PLPProductList from "@components/plp/PLPProductList";
 import FilterBottomSheet from "@components/plp/FilterBottomSheet";
 import Error from "@common/Error";
 import { TChatResponse } from "@type/chat";
@@ -60,7 +60,7 @@ const ProductsPLP = (props: ProductsPLPProps) => {
       {data && filteredProducts && (
         <>
           {/* 상품 영역 */}
-          <PLPProductDisplay products={filteredProducts} />
+          <PLPProductList products={filteredProducts} />
 
           {/* 필터 바텀 */}
           <FilterBottomSheet

--- a/frontend/src/pages/Chat/Chat.tsx
+++ b/frontend/src/pages/Chat/Chat.tsx
@@ -59,6 +59,10 @@ const Chat = () => {
       } finally {
         sessionStorage.removeItem("BottomSheetState");
       }
+    } else {
+      if (window.location.hash) {
+        history.replaceState(null, "", " ");
+      }
     }
   }, []);
 


### PR DESCRIPTION
## 요약

> 상품 리스트 무한스크롤 적용 및 productItem 컴포넌트 분리

<br/><br/>

## 변경 내용

> 렌더링이 오래 걸려서 개선하고자 적용하였습니다. 서버 측에서 페이징 처리를 할 수 없는 상황이라 프론트에서 청크 단위로 데이터를 쪼개어 무한 스크롤을 적용했습니다.

> productItem 컴포넌트 분리해서 사용하는 컴포넌트 수정했습니다.

> 바텀 최소화 위치 재수정 및 새로고침 시 hash 제거

<br/><br/>

## 헬프미 🙏

> 무한 스크롤 방식으로 목록이 계속 쌓이면 렌더링 성능에 영향을 줄 수 있다고 판단했습니다. 개선하기 위해 무한 스크롤 대신 가상화 처리를 도입하는 것이 더 효율적이라고 생각해서 적용중입니다.
react-window와 react-virtualized 두 가지 라이브러리를 사용해보았는데, react-window는 자식 요소의 높이를 동적으로 처리하기 어려워 react-virtualized로 최종 적용했습니다. 현재 자식 요소의 크기가 동적으로 불러와지는데, 리사이즈 시 넓이 값이 실시간으로 반영되지 않는 문제가 있어 이를 해결 중입니다.
살려주세요.. 여러분.. 좋은 해결 방법이 없을까요..? 이것 때문에 아주..하.. 다른 작업하고 다시 해봐야할 것 같습니다. #120 이슈 참고 바랍니다.

<br/><br/>

## 이슈 번호 또는 링크
#120

<br/><br/>