### PR TITLE
fix: 회원가입 import path 대소문자 에러 해결

### DIFF
--- a/frontend/src/components/login/LoginBottomSheet.tsx
+++ b/frontend/src/components/login/LoginBottomSheet.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import BottomSheet from "@common/BottomSheet";
 import Login from "@components/login/Login";
-import SignUp from "@components/signUp/SignUp";
+import SignUp from "@components/signup/SignUp";
 
 const LoginBottomSheet = () => {
   const location = useLocation();

--- a/frontend/src/components/signup/SignUp.tsx
+++ b/frontend/src/components/signup/SignUp.tsx
@@ -1,5 +1,5 @@
-import SignUpRequired from "@components/signUp/SignUpRequired";
-import SignUpAdditional from "@components/signUp/SignUpAdditional";
+import SignUpRequired from "@components/signup/SignUpRequired";
+import SignUpAdditional from "@components/signup/SignUpAdditional";
 import userStore from "@store/auth.store.ts";
 import { redirect } from "react-router-dom";
 


### PR DESCRIPTION
## 요약

> 내용을 입력해 주세요
회원가입 import path 대소문자 에러 해결

<br/><br/>

## 변경 내용

> 내용을 입력해 주세요

```javascript
src/components/login/LoginBottomSheet.tsx(5,20): error TS2307: Cannot find module '@components/signUp/SignUp' or its corresponding type declarations.
src/components/signup/SignUp.tsx(1,28): error TS2307: Cannot find module '@components/signUp/SignUpRequired' or its corresponding type declarations.
src/components/signup/SignUp.tsx(2,30): error TS2307: Cannot find module '@components/signUp/SignUpAdditional' or its corresponding type declarations.
```
회원가입 관련된 컴포넌트에서 path 대소문자가 맞지 않아 빌드 에러 발생하여 @components/signUp/.. -> @components/signup/.. 으로 수정하였습니다.

<br/><br/>

## 이슈 번호 또는 링크
[actions build error](https://github.com/StepUpper/stepup_front/actions/runs/13488504952), #168, #169
<br/><br/>